### PR TITLE
Update start.sh to ignore beta and alpha version of drupal

### DIFF
--- a/files/start.sh
+++ b/files/start.sh
@@ -26,7 +26,7 @@ if [ ! -f ${DOCROOT}/index.php ]; then
   echo "**** No Drupal found. Downloading latest to ${DOCROOT}/ ****"
   cd ${BASEHTML}
   # Get the latest version number
-  DV=$(curl -s https://git.drupalcode.org/project/drupal/-/tags?format=atom | grep -e '<title>' | grep -Eo '[0-9\.]+' | sort -nr | grep ^${DRUPALVER} | head -n1)
+  DV=$(curl -s https://git.drupalcode.org/project/drupal/-/tags?format=atom | grep -e '<title>' | grep --invert-match -e "beta" -e "alpha" | grep -Eo '[0-9\.]+' | sort -nr | grep ^${DRUPALVER} | head -n1)
   git clone --depth 1 --single-branch -b ${DV} \
     https://git.drupalcode.org/project/drupal.git web
   # TODO: also require drupal/memcache


### PR DESCRIPTION
This pull request updates the start.sh file to ignore betas and alphas version of drupal. When we map the directory from local host to container, it tries to get the newest version of the drupal 9 from the drupal's repository by using git's tags. However, it is trying to download the 9.5.0 version which is a beta version. It fails because there is no such 9.5.0 tag in the drupal's repository, the one that exists is the 9.5.0-beta1, therefore it fails.

The current start.sh:
<img width="1440" alt="Screen Shot 2022-09-19 at 10 55 57 PM" src="https://user-images.githubusercontent.com/58089014/191150287-f4f03ecd-0e0a-4adf-8b73-2c7532614722.png">

<img width="1440" alt="Screen Shot 2022-09-19 at 10 57 57 PM" src="https://user-images.githubusercontent.com/58089014/191150526-c9c514bf-8d45-46c0-bb62-8ede539a6019.png">

<img width="529" alt="Screen Shot 2022-09-19 at 10 58 55 PM" src="https://user-images.githubusercontent.com/58089014/191150647-13b69842-fb80-4b6e-8106-62dc7600c81a.png">

The update version of start.sh:
<img width="1440" alt="Screen Shot 2022-09-19 at 10 59 30 PM" src="https://user-images.githubusercontent.com/58089014/191150721-349f4774-7674-4c78-ab2b-9c7743a66048.png">

Therefore, with this updated version of start.sh, we are able to overcome the problem when the latest tag is a beta or alpha version.

